### PR TITLE
Add support for custom button text via shortcode.

### DIFF
--- a/functions/form.php
+++ b/functions/form.php
@@ -36,9 +36,16 @@ class don8 {
 <input type="hidden" name="business" value="' . esc_html( $email ) . '">
 <input type="hidden" name="item_name" value="' . esc_html( $cause ) . '">
 <input type="hidden" name="currency_code" value="' . esc_html( $currency ) . '">
-<input type="hidden" name="amount" value="' . esc_html( $value ) . '">
-<input type="image" src="' . esc_html( $button ) . '" border="0" name="submit" alt="Donate to ' . esc_html( $cause ) . '">
-</form>';
+<input type="hidden" name="amount" value="' . esc_html( $value ) . '">';
+
+        // Check of the `button` parameter is a valid URL, otherwise use as custom button text.
+        if( filter_var($button, FILTER_VALIDATE_URL) ) {
+            $don8_button .= '<input type="image" src="' . esc_html($button) . '" border="0" name="submit" alt="Donate to ' . esc_html($cause) . '">';
+        } else {
+            $don8_button .= '<input type="submit" name="submit" alt="Donate to ' . esc_html($cause) . '" value="' . esc_html($button) . '">';
+        }
+
+        $don8_button .= '</form>';
 
 		return $don8_button;
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -26,6 +26,14 @@ email="kyle@test.com"
 amount="10000000000"
 button="http://example.com/images/button.png"]`
 
+The button parameter can also accept custom button text:
+
+`[don8 cause="Adoption Fund"
+currency="USD"
+email="kyle@test.com"
+amount="10000000000"
+button="Help Us Today"]`
+
 This example would render a PayPal button which, when clicked on, would take the user to a PayPal screen where they can enter in their payment information to make a donation to kyle@test.com for $10,000,000,000 towards the Adoption Fund.
 
 == Installation ==


### PR DESCRIPTION
Closes #7. 

Uses `filter_var($button, FILTER_VALIDATE_URL)` to determine if the button parameter is a valid URL, otherwise creates a `submit` type `input` with custom text.

Reference: http://php.net/manual/en/filter.filters.validate.php

Example use via shortcode:

```
[don8
 cause="Adoption Fund"
 currency="USD"
 email="kyle@test.com"
 amount="10000000000"
 button="Help Us Today"
]
```
