### PR TITLE
Add tinymce button.

### DIFF
--- a/admin/tinymce.php
+++ b/admin/tinymce.php
@@ -1,8 +1,72 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: kylemaurer
- * Date: 9/27/14
- * Time: 10:58 AM
- */
 
+final class don8TinyMCE
+{
+    function __construct()
+    {
+        // Add a tinyMCE button to our post and page editor
+        add_filter( 'media_buttons_context', array( $this, 'insert_button' ) );
+    }
+
+    public function insert_button( $context )
+    {
+        global $pagenow;
+        if( 'post.php' != $pagenow ){
+            return $context;
+        }
+
+        add_thickbox();
+
+        $button_text = __( 'Add Donate Button', '' );
+
+        return '
+<a id="don8" class="button thickbox" href="#TB_inline?width=100%&height=100%&inlineId=don8-thickbox" data-editor="content">
+    <span class="don8-icon"></span>
+    ' . $button_text . '
+</a>
+<div id="don8-thickbox" style="display:none;">
+
+    <h2>' . $button_text . '</h2>
+
+    <p>
+        <label for="don8-cause">' . __( 'Cause', 'don8' ) . '</label>
+        <input type="text" id="don8-cause" name="don8-cause" class="widefat" value="' . get_option( 'don8_cause' ) . '">
+    </p>
+    
+    <p>
+        <label for="don8-currency">' . __( 'Currency Code', 'don8' ) . '</label>
+        <input type="text" id="don8-currency" name="don8-currency" class="widefat" value="' . get_option( 'don8_currency' ) . '">
+    </p>
+    
+    <p>
+        <label for="don8-amount">' . __( 'Amount', 'don8' ) . '</label>
+        <input type="text" id="don8-amount" name="don8-amount" class="widefat" value="' . get_option( 'don8_value' ) . '">
+    </p>
+    
+    <p>
+        <label for="don8-button">' . __( 'Button', 'don8' ) . '</label>
+        <input type="text" id="don8-button" name="don8-button" class="widefat" value="' . $this->get_button() . '">
+    </p>
+
+    <p>
+        <button id="add-don8" class="button button-primary">' . $button_text . '</button>
+    </p>
+
+</div>
+        ';
+    }
+
+    protected function get_button()
+    {
+        $button = get_option( 'don8_button' );
+        if( filter_var( $button, FILTER_VALIDATE_INT ) ){
+            $button = filter_var( $button, FILTER_VALIDATE_INT );
+            $button = wp_get_attachment_image_src( $button );
+            $button = array_shift( $button );
+        }
+        return $button;
+    }
+
+}
+
+$don8 = new don8TinyMCE();

--- a/don8.php
+++ b/don8.php
@@ -17,6 +17,7 @@ Author URI: http://realbigmarketing.com/staff/kyle
 // Include the back-end media uploader!
 require_once( plugin_dir_path( __FILE__ ) . '/functions/uploader.php' );
 require_once( plugin_dir_path( __FILE__ ) . '/admin/admin.php' );
+require_once( plugin_dir_path( __FILE__ ) . '/admin/tinymce.php' );
 require_once( plugin_dir_path( __FILE__ ) . '/admin/widget.php' );
 require_once( plugin_dir_path( __FILE__ ) . '/functions/form.php' );
 
@@ -56,6 +57,9 @@ function don8_scripts( $hook ) {
 		wp_enqueue_script( 'don8', plugins_url( '/js/script.js', __FILE__ ), array( 'jquery' ) );
 		wp_enqueue_media();
 	}
+    if ( $hook == 'post.php' ) {
+        wp_enqueue_script( 'don8-tinymce', plugins_url( '/js/tinymce.js', __FILE__ ), array( 'jquery' ) );
+    }
 }
 
 add_action( 'admin_enqueue_scripts', 'don8_scripts' );

--- a/js/tinymce.js
+++ b/js/tinymce.js
@@ -1,0 +1,20 @@
+jQuery( document ).ready( function( $ ) {
+
+    $( document ).on( 'click', '#add-don8', function( e ) {
+        e.preventDefault();
+
+        var cause = $( '#don8-cause' ).val();
+        var currency = $( '#don8-currency' ).val();
+        var amount = $( '#don8-amount' ).val();
+        var button = $( '#don8-button' ).val();
+
+
+        var shortcode = '[don8 ' +
+            'cause="' + cause + '" ' +
+            'currency="' + currency + '" ' +
+            'amount="' + amount + '" ' +
+            'button="' + button + '"]';
+
+        window.parent.send_to_editor( shortcode );
+    });
+});


### PR DESCRIPTION
Closes #1.

Adds a tinyMCE button to the post editor for inserting a don8 shortcode.

The modal uses plugin setting defaults, which can be modified before inserting the shortcode.

If the button default is a media library image, the modal assumes the thumbnail URL for that image.

<img width="826" alt="screenshot 2016-10-03 00 08 16" src="https://cloud.githubusercontent.com/assets/10858303/19027394/055b26aa-88fe-11e6-845f-207c0fc4f630.png">

<img width="796" alt="screenshot 2016-10-03 00 08 51" src="https://cloud.githubusercontent.com/assets/10858303/19027397/0bd49c64-88fe-11e6-97fc-5a049011c7c3.png">
